### PR TITLE
fix typo in code example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Example usage::
             ( (0, 0, 0), 'black' )
         )
     
-        @data_provider(colors):
+        @data_provider(colors)
         def test_parse_color(self, color, notation):
             self.assertEquals(color, self.parser.parse_color(notation))
 


### PR DESCRIPTION
There was an extra colon after the decorator.